### PR TITLE
Implement logout endpoint.

### DIFF
--- a/app/controllers/concerns/gamora/authorization_url.rb
+++ b/app/controllers/concerns/gamora/authorization_url.rb
@@ -1,0 +1,37 @@
+module Gamora
+  module AuthorizationUrl
+    def authorization_url(params, extra_params = {})
+      default_params = {
+        scope: Configuration.default_scope,
+        theme: Configuration.default_theme,
+        prompt: Configuration.default_prompt,
+        strategy: Configuration.default_strategy,
+        branding: Configuration.default_branding,
+        ui_locales: Configuration.ui_locales.call
+      }
+
+      data =
+        default_params.
+        merge(extra_params).
+        merge(authorization_params(params)).
+        compact_blank
+
+      Client.from_config.auth_code.authorize_url(data)
+    end
+
+    private
+
+    def authorization_params(params)
+      params.permit(
+        :scope,
+        :state,
+        :theme,
+        :prompt,
+        :max_age,
+        :strategy,
+        :branding,
+        :ui_locales
+      )
+    end
+  end
+end

--- a/app/controllers/gamora/callback_controller.rb
+++ b/app/controllers/gamora/callback_controller.rb
@@ -7,6 +7,7 @@ module Gamora
       session[:access_token] = access_token.token
       session[:refresh_token] = access_token.refresh_token
       redirect_to session.delete("gamora.origin") || main_app.root_path
+
     rescue OAuth2::Error
       render plain: "Invalid authorization code"
     end

--- a/app/controllers/gamora/unauthentication_controller.rb
+++ b/app/controllers/gamora/unauthentication_controller.rb
@@ -1,11 +1,13 @@
 # frozen_string_literal: true
 
 module Gamora
-  class AuthenticationController < ApplicationController
+  class UnauthenticationController < ApplicationController
     include AuthorizationUrl
 
     def show
-      redirect_to authorization_url(params),
+      session[:access_token] = nil
+
+      redirect_to authorization_url(params, { max_age: 0 }),
         allow_other_host: true,
         status: :see_other
     end

--- a/app/controllers/gamora/unauthentication_controller.rb
+++ b/app/controllers/gamora/unauthentication_controller.rb
@@ -6,6 +6,7 @@ module Gamora
 
     def show
       session[:access_token] = nil
+      session[:refresh_token] = nil
 
       redirect_to authorization_url(params, { max_age: 0 }),
         allow_other_host: true,

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,6 @@
 
 Gamora::Engine.routes.draw do
   get "amco", to: "authentication#show", as: :authentication
+  get "logout", to: "unauthentication#show", as: :logout
   get "amco/callback", to: "callback#show", as: :callback
 end

--- a/lib/gamora/version.rb
+++ b/lib/gamora/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Gamora
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
 end


### PR DESCRIPTION
## Addresses issue: [#IDP-111](https://amcoit.atlassian.net/browse/IDP-111)

NOTE:
By this time BorutaEx has not implemented the OpenID Connect protocol for logout. The temporary solution is to remove access_token and refresh token from session and redirect user to authenticate again.