### PR TITLE
Allow oauth newer versions

### DIFF
--- a/gamora.gemspec
+++ b/gamora.gemspec
@@ -26,6 +26,6 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   end
 
-  spec.add_dependency "oauth2", "~> 1.4"
+  spec.add_dependency "oauth2", ">= 1.4"
   spec.add_dependency "rails", ">= 6.0"
 end


### PR DESCRIPTION
Allow newer oauth gem versions in the gemspec file.

oauth 2.0+ was already tested in some applications and works well.