### PR TITLE
Add support for roles claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,12 @@
 # Changelog
 
+## [0.8.0] - 2023-11-21
+
+- Add support for `roles` claim.
+
 ## [0.7.0] - 2023-11-02
 
-- Add support `email_verified` and `phone_number_verified` claims.
+- Add support for `email_verified` and `phone_number_verified` claims.
 
 ## [0.6.1] - 2023-07-21
 
@@ -23,11 +27,11 @@ to the IDP again.
 
 ## [0.3.0] - 2022-08-04
 
-- Add support to `branding` param in the authorization url.
+- Add support for `branding` param in the authorization url.
 
 ## [0.2.0] - 2022-07-28
 
-- Add support to `theme` param in the authorization url.
+- Add support for `theme` param in the authorization url.
 
 ## [0.1.0] - 2022-05-20
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    gamora (0.7.0)
+    gamora (0.8.0)
       oauth2 (>= 1.4)
       rails (>= 6.0)
 

--- a/lib/gamora/authentication/base.rb
+++ b/lib/gamora/authentication/base.rb
@@ -5,6 +5,7 @@ module Gamora
     module Base
       CLAIMS = {
         sub: :id,
+        roles: :roles,
         email: :email,
         given_name: :first_name,
         family_name: :last_name,

--- a/lib/gamora/user.rb
+++ b/lib/gamora/user.rb
@@ -5,6 +5,7 @@ module Gamora
     include ActiveModel::Model
 
     attr_accessor :id,
+                  :roles,
                   :email,
                   :last_name,
                   :first_name,

--- a/lib/gamora/version.rb
+++ b/lib/gamora/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Gamora
-  VERSION = "0.7.0"
+  VERSION = "0.8.0"
 end

--- a/spec/gamora/user_spec.rb
+++ b/spec/gamora/user_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe Gamora::User do
         last_name: "Bar",
         phone_number: "+523344556677",
         email_verified: true,
-        phone_number_verified: false
+        phone_number_verified: false,
+        roles: { denali: ["publisher"] }
       }
     end
 


### PR DESCRIPTION
## Addresses issue: [#IDP-225](https://amcoit.atlassian.net/browse/IDP-225)

If the `roles` scope was provided to the IDP, the claims will include a roles key. This PR adds the support to have that attribute in the Gamora.User module.